### PR TITLE
[master] Michijs Dependabot changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,21 +22,21 @@
   },
   "devDependencies": {
     "@michijs/tsconfig": "0.0.5",
-    "@michijs/dev-server": "0.8.6",
+    "@michijs/dev-server": "0.8.7",
     "@michijs/storybook-utils": "8.4.7",
-    "@storybook/addon-a11y": "8.4.7",
-    "@storybook/addon-controls": "8.4.7",
-    "@storybook/addon-docs": "8.4.7",
-    "@storybook/addon-links": "8.4.7",
-    "@storybook/addon-storysource": "8.4.7",
-    "@storybook/addon-viewport": "8.4.7",
-    "@storybook/builder-vite": "8.4.7",
-    "@storybook/web-components-vite": "8.4.7",
-    "storybook": "8.4.7",
+    "@storybook/addon-a11y": "9.1.2",
+    "@storybook/addon-controls": "9.0.8",
+    "@storybook/addon-docs": "9.1.2",
+    "@storybook/addon-links": "9.1.2",
+    "@storybook/addon-storysource": "8.6.14",
+    "@storybook/addon-viewport": "9.0.8",
+    "@storybook/builder-vite": "9.1.2",
+    "@storybook/web-components-vite": "9.1.2",
+    "storybook": "9.1.2",
     "storybook-dark-mode": "4.0.2",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   },
-  "packageManager": "bun@1.1.20",
+  "packageManager": "bun@1.2.20",
   "peerDependencies": {
     "@mdi/js": "^7.4.47",
     "@michijs/michijs": "^2.1.10"


### PR DESCRIPTION
## Updated Packages

<ul><li>Bump <a href="https://github.com/oven-sh/bun">bun</a> from <a href="#user-content-bump-bun">1.1.20 to 1.2.20</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">@storybook/addon-viewport</a> from <a href="#user-content-bump-@storybook/addon-viewport">8.4.7 to 9.0.8</a></li><li>Bump <a href="https://github.com/michijs/dev-server">@michijs/dev-server</a> from <a href="#user-content-bump-@michijs/dev-server">0.8.6 to 0.8.7</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">@storybook/web-components-vite</a> from <a href="#user-content-bump-@storybook/web-components-vite">8.4.7 to 9.1.2</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">@storybook/builder-vite</a> from <a href="#user-content-bump-@storybook/builder-vite">8.4.7 to 9.1.2</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">@storybook/addon-a11y</a> from <a href="#user-content-bump-@storybook/addon-a11y">8.4.7 to 9.1.2</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">@storybook/addon-links</a> from <a href="#user-content-bump-@storybook/addon-links">8.4.7 to 9.1.2</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">@storybook/addon-storysource</a> from <a href="#user-content-bump-@storybook/addon-storysource">8.4.7 to 8.6.14</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">@storybook/addon-controls</a> from <a href="#user-content-bump-@storybook/addon-controls">8.4.7 to 9.0.8</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">@storybook/addon-docs</a> from <a href="#user-content-bump-@storybook/addon-docs">8.4.7 to 9.1.2</a></li><li>Bump <a href="https://github.com/microsoft/TypeScript">typescript</a> from <a href="#user-content-bump-typescript">5.8.3 to 5.9.2</a></li><li>Bump <a href="https://github.com/storybookjs/storybook">storybook</a> from <a href="#user-content-bump-storybook">8.4.7 to 9.1.2</a></li></ul>